### PR TITLE
ci: remove `cla: yes` from required labels (#44179)

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -100,7 +100,6 @@ merge:
     # list of labels that a PR needs to have, checked with a regexp (e.g. "target:" will work for the label "target: master")
     requiredLabels:
       - 'target: *'
-      - 'cla: yes'
 
     # list of labels that a PR shouldn't have, checked after the required labels with a regexp
     forbiddenLabels:
@@ -108,7 +107,6 @@ merge:
       - 'action: cleanup'
       - 'action: review'
       - 'state: blocked'
-      - 'cla: no'
 
     # list of PR statuses that need to be successful
     requiredStatuses:


### PR DESCRIPTION
Remove `cla: yes` from the require labels for merging as the CLACheck
tool no longer relies on labels.

Enforcement of the CLA being signed is still enforced by the status check
which is visible both in Github as well as checked by merge tooling.

PR Close #44179

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
